### PR TITLE
use `fill` attribute instead of inline styles

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -53,7 +53,7 @@ const renderPixels = (hash: string) => {
 
 const pixelsToSvg = (pixels: Rectangle[]): string => {
   let xml = `<svg xmlns="http://www.w3.org/2000/svg" width="28" height="28">
-    <g style="fill: currentColor">`
+    <g fill="currentColor">`
 
   pixels.forEach((pixel) => {
     if (!pixel.isPixel) {


### PR DESCRIPTION
While working on https://github.com/oxidecomputer/console/pull/2142 I ran into `content-security-policy` violations due to inline styles. After finding out that React applies styles using the `style` attribute in a way that's compatible with CSP I tried to figure out what the violations were; it turns out all of them were due to the `style=` attribute in the SVG generated by this library.

Using `fill` directly allows use of a stricter `content-security-policy` that does not require allowing `style-src: 'unsafe-inline'`.

(Tested by hand-patching `node_modules/@oxide/identicon/dist/identicon.js` in my console environment.)